### PR TITLE
Fixed oc location

### DIFF
--- a/documentation/modules/ROOT/pages/lab-setup.adoc
+++ b/documentation/modules/ROOT/pages/lab-setup.adoc
@@ -55,7 +55,7 @@ dnf -y install kcli bash-completion vim jq tar git python3-cherrypy
 [source,bash,subs="attributes+,+macros"]
 -----
 kcli download oc -P version=stable -P tag='{tooling-version}'
-mv oc /usr/bin/
+mv oc /usr/local/bin/
 -----
 
 [#configure-lab-network]


### PR DESCRIPTION
Replaced the `oc` installation path from `/usr/bin` to `/usr/local/bin`.

Reason: it is generally considered best practice to use `/usr/local` subfolders for content installed by means others than the package manager, while `/usr/bin` etc. outside `local` should be used for package-managed binaries only.