### PR TITLE
Fixed dnsmasq SELinux config

### DIFF
--- a/documentation/modules/ROOT/pages/lab-setup.adoc
+++ b/documentation/modules/ROOT/pages/lab-setup.adoc
@@ -82,8 +82,9 @@ curl -sL https://raw.githubusercontent.com/RHsyseng/hypershift-baremetal-lab/{br
 curl -sL https://raw.githubusercontent.com/RHsyseng/hypershift-baremetal-lab/{branch}/lab-materials/lab-env-data/dnsmasq/infrastructure-host.ipv4 -o /opt/dnsmasq/include.d/infrastructure-host.ipv4
 curl -sL https://raw.githubusercontent.com/RHsyseng/hypershift-baremetal-lab/{branch}/lab-materials/lab-env-data/dnsmasq/dnsmasq-virt.service -o /etc/systemd/system/dnsmasq-virt.service
 touch /opt/dnsmasq/hosts.leases
-semanage fcontext -a -t dnsmasq_lease_t /opt/dnsmasq/hosts.leases
-restorecon /opt/dnsmasq/hosts.leases
+semanage fcontext -a -t dnsmasq_etc_t '/opt/dnsmasq(/.*)?'         # semanage commands order is important
+semanage fcontext -a -t dnsmasq_lease_t /opt/dnsmasq/hosts.leases  # senabage commands order is important
+restorecon -vr /opt/dnsmasq/
 sed -i "s/UPSTREAM_DNS/1.1.1.1/" /opt/dnsmasq/upstream-resolv.conf
 systemctl daemon-reload
 systemctl enable dnsmasq-virt --now


### PR DESCRIPTION
With the current configuration, dnsmasq-virt failed to start because dnsmasq config files didn't have `dnsmasq_etc_t` SELinux type. 

By default, with the current instructions applied on a vainilla RHEL9 system, we get the following SELinux labeling:
```
$ getenforce
Enforcing

$ ls -lhZ /opt/dnsmasq/*
-rw-r--r--. 1 root root unconfined_u:object_r:usr_t:s0           539 Nov 28 03:42 /opt/dnsmasq/dnsmasq.conf
-rw-r--r--. 1 root root unconfined_u:object_r:dnsmasq_lease_t:s0   0 Nov 28 03:43 /opt/dnsmasq/hosts.leases
-rw-r--r--. 1 root root unconfined_u:object_r:usr_t:s0            46 Nov 28 03:44 /opt/dnsmasq/upstream-resolv.conf

/opt/dnsmasq/include.d:
total 12K
-rw-r--r--. 1 root root unconfined_u:object_r:usr_t:s0 338 Nov 28 03:42 hosted.ipv4
-rw-r--r--. 1 root root unconfined_u:object_r:usr_t:s0  47 Nov 28 03:42 infrastructure-host.ipv4
-rw-r--r--. 1 root root unconfined_u:object_r:usr_t:s0 455 Nov 28 03:42 management.ipv4
```

So dnsmasq is not allowed to access the configuration files and fails to start with this error in the journal:
```
Nov 28 03:55:14 mybigmachine.example.com systemd[1]: Started DNS server for Openshift 4 Clusters..
   Subject: A start job for unit dnsmasq-virt.service has finished successfully
   Defined-By: systemd
   Support: https://access.redhat.com/support
   
   A start job for unit dnsmasq-virt.service has finished successfully.
   
   The job identifier is 5744.
Nov 28 03:55:14 mybigmachine.example.com dnsmasq[52067]: dnsmasq: failed to create inotify for /opt/dnsmasq/upstream-resolv.conf: Permission denied
Nov 28 03:55:14 mybigmachine.example.com dnsmasq[52067]: failed to create inotify for /opt/dnsmasq/upstream-resolv.conf: Permission denied
Nov 28 03:55:14 mybigmachine.example.com systemd[1]: dnsmasq-virt.service: Main process exited, code=exited, status=5/NOTINSTALLED
   Subject: Unit process exited
   Defined-By: systemd
   Support: https://access.redhat.com/support
   
   An ExecStart= process belonging to unit dnsmasq-virt.service has exited.
   
   The process' exit code is 'exited' and its exit status is 5.
Nov 28 03:55:14 mybigmachine.example.com dnsmasq[52067]: FAILED to start up
Nov 28 03:55:14 mybigmachine.example.com systemd[1]: dnsmasq-virt.service: Failed with result 'exit-code'.
   Subject: Unit failed
   Defined-By: systemd
   Support: https://access.redhat.com/support
   
   The unit dnsmasq-virt.service has entered the 'failed' state with result 'exit-code'.
```

The fixed instructions set the `dnsmasq_etc_t` type for the whole `/opt/dnsmasq` folder except `/opt/dnsmasq/hosts.leases`, which gets the `dnsmasq_lease_t` as before (to achieve this, `semanage fcontext` commands must be run in the documented order, hence why I added an explicit warning)