### PR TITLE
Limit dnsmasq-virt to hypershiftlab interface

### DIFF
--- a/lab-materials/lab-env-data/dnsmasq/dnsmasq.conf
+++ b/lab-materials/lab-env-data/dnsmasq/dnsmasq.conf
@@ -9,6 +9,7 @@ dhcp-option=hypershiftlab,option:dns-server,192.168.125.1
 dhcp-option=hypershiftlab,option:router,192.168.125.1
 
 resolv-file=/opt/dnsmasq/upstream-resolv.conf
+interface=hypershiftlab
 except-interface=lo
 dhcp-lease-max=81
 log-dhcp


### PR DESCRIPTION
Previously, dnsmasq-virt was listening in all the interfaces, including main one. In the best case, this results in annoying logs each time there is a DHCP request on the main network (I have preferred to not look for a worse case).